### PR TITLE
fix italian strings.xml

### DIFF
--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -26,8 +26,6 @@
   <string name="faq_hint" formatted="false" username="carloraudino@fedoraproject.org" orig="Some tips and tricks, how to set up this app.">Alcuni trucchi e suggerimenti su come impostare l\'applicazione.</string>
   <string name="feedback_" formatted="false" username="carloraudino@fedoraproject.org" orig="Feedback">Feedback</string>
   <string name="feedback_hint" formatted="false" username="carloraudino@fedoraproject.org" orig="Report bugs, request features ...">Segnala bug, richiedi funzioni ...</string>
-&#13;
-Ricevi notifiche su aggiornamenti ecc.</string>
   <string name="about0" formatted="false" username="carloraudino@fedoraproject.org" orig="SMSdroid lets you read your sms and write sms with any other app.">SMSdroid permette la lettura di SMS e l\'invio attraverso altre applicazioni.</string>
   <string name="more_apps_" formatted="false" username="carloraudino@fedoraproject.org" orig="More Apps..">Altre app..</string>
   <string name="settings" formatted="false" username="carloraudino@fedoraproject.org" orig="Preferences">Impostazioni</string>


### PR DESCRIPTION
the commit 4dd5a248b154a9aa661c69e17fa3446482991b31 removed the
"twitter_hint" everywhere, but in values-it/strings.xml this string was
multiline, so that the xml is invalid now which prevents the build
