### PR TITLE
Allow work mobile phone numbers when filtering on mobile numbers.

### DIFF
--- a/src/de/ub0r/android/smsdroid/MobilePhoneAdapter.java
+++ b/src/de/ub0r/android/smsdroid/MobilePhoneAdapter.java
@@ -120,7 +120,8 @@ public class MobilePhoneAdapter extends ResourceCursorAdapter {
 	@Override
 	public final Cursor runQueryOnBackgroundThread(final CharSequence constraint) {
 		String s = constraint == null ? null : constraint.toString();
-		String where = prefsMobilesOnly ? Phone.TYPE + " = " + Phone.TYPE_MOBILE : null;
+		String where = prefsMobilesOnly ? Phone.TYPE + " = " + Phone.TYPE_MOBILE + " OR "
+				+ Phone.TYPE + " = " + Phone.TYPE_WORK_MOBILE : null;
 		Uri u = Uri.withAppendedPath(Phone.CONTENT_FILTER_URI, Uri.encode(s));
 		Cursor cursor = this.mContentResolver.query(u, PROJECTION, where, null, Phone.DISPLAY_NAME);
 		return cursor;


### PR DESCRIPTION
Filtering on mobile numbers only allowed mobile numbers but not numbers of
"work mobile phone" type. Include those as well.
