### PR TITLE
Add option to handle text as short message in compose boxes.

### DIFF
--- a/SMSdroid/src/main/java/de/ub0r/android/smsdroid/MessageListActivity.java
+++ b/SMSdroid/src/main/java/de/ub0r/android/smsdroid/MessageListActivity.java
@@ -38,6 +38,7 @@ import android.preference.PreferenceManager;
 import android.provider.CallLog.Calls;
 import android.support.v4.app.FragmentActivity;
 import android.text.ClipboardManager;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.text.format.DateFormat;
 import android.view.View;
@@ -281,6 +282,14 @@ public class MessageListActivity extends SherlockActivity implements OnItemClick
 
         cbmgr = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
         etText = (EditText) findViewById(R.id.text);
+        int flags = etText.getInputType();
+        if (p.getBoolean(PreferencesActivity.PREFS_EDIT_SHORT_TEXT, true)) {
+            flags |= InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
+        }
+        else {
+            flags &= ~InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
+        }
+        etText.setInputType(flags);
 
         if (!showTextField) {
             findViewById(R.id.text_layout).setVisibility(View.GONE);

--- a/SMSdroid/src/main/java/de/ub0r/android/smsdroid/PreferencesActivity.java
+++ b/SMSdroid/src/main/java/de/ub0r/android/smsdroid/PreferencesActivity.java
@@ -106,6 +106,8 @@ public class PreferencesActivity extends PreferenceActivity implements IPreferen
 	public static final String PREFS_ENABLE_AUTOSEND = "enable_autosend";
 	/** Preference's name: mobile_only. */
 	public static final String PREFS_MOBILE_ONLY = "mobile_only";
+	/** Preference's name: edit_short_text. */
+	public static final String PREFS_EDIT_SHORT_TEXT = "edit_short_text";
 	/** Preference's name: show text field. */
 	public static final String PREFS_SHOWTEXTFIELD = "show_textfield";
 	/** Preference's name: show target app. */

--- a/SMSdroid/src/main/java/de/ub0r/android/smsdroid/SenderActivity.java
+++ b/SMSdroid/src/main/java/de/ub0r/android/smsdroid/SenderActivity.java
@@ -21,6 +21,7 @@ import android.provider.BaseColumns;
 import android.telephony.SmsManager;
 import android.telephony.SmsMessage;
 import android.text.ClipboardManager;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -147,6 +148,14 @@ public final class SenderActivity extends SherlockActivity implements OnClickLis
 					mtv.requestFocus();
 				}
 				cbmgr = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+				int flags = et.getInputType();
+				if (p.getBoolean(PreferencesActivity.PREFS_EDIT_SHORT_TEXT, true)) {
+					flags |= InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
+				}
+				else {
+					flags &= ~InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
+				}
+				et.setInputType(flags);
 			}
 		}
 	}

--- a/SMSdroid/src/main/res/layout/messagelist.xml
+++ b/SMSdroid/src/main/res/layout/messagelist.xml
@@ -61,7 +61,7 @@
                     android:gravity="top"
                     android:hint="@string/text_hint"
                     android:imeOptions="actionDone|flagNoEnterAction"
-                    android:inputType="textShortMessage|textMultiLine|textAutoCorrect|textCapSentences"
+                    android:inputType="textMultiLine|textCapSentences|textAutoCorrect"
                     android:maxLines="4"
                     android:nextFocusRight="@+id/send_"/>
 

--- a/SMSdroid/src/main/res/values-de/strings.xml
+++ b/SMSdroid/src/main/res/values-de/strings.xml
@@ -230,6 +230,8 @@
   <string name="source_" formatted="false" username="Schiri &lt;schirinowski@gmail.com&gt;" orig="Sourcescode:">Quelltext:</string>
   <string name="mobile_only_">Nur Mobilnummern</string>
   <string name="mobile_only_hint">Für Empfänger nur Mobilnummern vorschlagen</string>
+  <string name="edit_short_text_">Als kurze Nachricht editieren</string>
+  <string name="edit_short_text_hint">Eingabe als kurze Nachricht betrachten. Die Tastatur ersetzt dann normalerweise Enter durch Smileys.</string>
   <string name="permission_save_to_db">Nachrichten in Datenbank speichern</string>
   <string name="permission_save_to_db_description">Nachrichten anderer Apps in Datenbank speichern</string>
   <string name="not_default_app">SMSdroid ist nicht die Standard SMS App</string>

--- a/SMSdroid/src/main/res/values/strings.xml
+++ b/SMSdroid/src/main/res/values/strings.xml
@@ -227,6 +227,8 @@
     <string name="changelog_" translatable="false">Changelog</string>
     <string name="mobile_only_">Only mobile numbers</string>
     <string name="mobile_only_hint">Only suggest mobile numbers for recipient</string>
+    <string name="edit_short_text_">Edit as short message</string>
+    <string name="edit_short_text_hint">Consider input a short message. The keyboard usually replaces enter with smiley button if enabled.</string>
     <string name="permission_save_to_db">Save messages to database</string>
     <string name="permission_save_to_db_description">Save messages sent by other apps to android message database</string>
     <string name="not_default_app">SMSdroid is not the default SMS app</string>

--- a/SMSdroid/src/main/res/xml/prefs_behavior.xml
+++ b/SMSdroid/src/main/res/xml/prefs_behavior.xml
@@ -38,7 +38,10 @@
                         android:title="@string/mobile_only_"
                         android:summary="@string/mobile_only_hint"
                         android:defaultValue="false"/>
-
+    <CheckBoxPreference android:key="edit_short_text"
+                        android:defaultValue="true"
+                        android:title="@string/edit_short_text_"
+                        android:summary="@string/edit_short_text_hint"/>
     <CheckBoxPreference android:key="forwarded_sms_clean"
                         android:title="@string/forwarded_sms_clean_"
                         android:summary="@string/forwarded_sms_clean_hint"


### PR DESCRIPTION
When composing a new message the EditText had TYPE_TEXT_VARIATION_SHORT_MESSAGE
unset while it was set when replying to an existing message. The flag usually
results in the keyboard replacing Enter with a Smiley button.

Since some people obviously like having Enter when composing SMS add an option
to change the state of TYPE_TEXT_VARIATION_SHORT_MESSAGE for those EditText
elements.

Addresses issue #646.
